### PR TITLE
Add option to run code for a sub-region of Toronto

### DIFF
--- a/solve_trt_greedy.py
+++ b/solve_trt_greedy.py
@@ -3,18 +3,19 @@ from utils.instance_generator import RealInstanceGenerator
 import argparse
 
 
-def solve_greedy(budget, metric, region=None):
+def solve_greedy(budget, metric, potential='job', region=None):
     # load data
     Generator = RealInstanceGenerator()
     args = Generator.generate(region=region)
     # initialize the solver
-    solver = GreedySolverPar(metric=metric, n_workers=4, region=region)
+    solver = GreedySolverPar(metric=metric, n_workers=4, potential=potential, region=region)
     solver.solve(args, budget)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--budget', type=int, help='road design budget')
+    parser.add_argument('--potential', type=str, help='type of accessibility', default='job')
     parser.add_argument('--region', type=str, help='region name', default=None)
     args = parser.parse_args()
-    solve_greedy(args.budget, 'abs', args.region)
+    solve_greedy(args.budget, 'abs', args.potential, args.region)

--- a/solve_trt_greedy.py
+++ b/solve_trt_greedy.py
@@ -3,18 +3,18 @@ from utils.instance_generator import RealInstanceGenerator
 import argparse
 
 
-def solve_greedy(budget, metric, region):
+def solve_greedy(budget, metric, region=None):
     # load data
     Generator = RealInstanceGenerator()
     args = Generator.generate(region=region)
     # initialize the solver
-    solver = GreedySolverPar(metric=metric, n_workers=4)
-    solver.solve(args, budget, region)
+    solver = GreedySolverPar(metric=metric, n_workers=4, region=region)
+    solver.solve(args, budget)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--budget', type=int, help='road design budget')
-    parser.add_argument('--region', type=str, help='region name')
+    parser.add_argument('--region', type=str, help='region name', default=None)
     args = parser.parse_args()
     solve_greedy(args.budget, 'abs', args.region)

--- a/solve_trt_greedy.py
+++ b/solve_trt_greedy.py
@@ -3,17 +3,18 @@ from utils.instance_generator import RealInstanceGenerator
 import argparse
 
 
-def solve_greedy(budget, metric):
+def solve_greedy(budget, metric, region):
     # load data
     Generator = RealInstanceGenerator()
-    args = Generator.generate()
+    args = Generator.generate(region=region)
     # initialize the solver
     solver = GreedySolverPar(metric=metric, n_workers=4)
-    solver.solve(args, budget)
+    solver.solve(args, budget, region)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--budget', type=int, help='road design budget')
+    parser.add_argument('--region', type=str, help='region name')
     args = parser.parse_args()
-    solve_greedy(args.budget, 'abs')
+    solve_greedy(args.budget, 'abs', args.region)

--- a/solve_trt_opt_cmd.py
+++ b/solve_trt_opt_cmd.py
@@ -10,13 +10,18 @@ import os
 import argparse
 
 
-def solve_trt(sn, n_sample, budgets, potential='job'):
+def solve_trt(sn, n_sample, budgets, potential='job', region=None):
+    # set sub-region suffix
+    if region == None:
+        suffix = ''
+    else:
+        suffix = '_{}'.format(region)
     # set params
     ins_name = 'trt'
     budget_sig = 0
     # load data
     print('loading data ...')
-    args, _ = load_file('./prob/trt/args_adj_ratio.pkl')
+    args, _ = load_file('./prob/trt/args_adj_ratio{}.pkl'.format(suffix))
     feature, _ = load_file('./prob/trt/emb/emb_ratio.pkl')
     selected_pairs = str2list(pd.read_csv('./prob/trt/pmedian/sample{}_p{}.csv'.format(sn, n_sample))['medians'].values[-1])
     # find neighbors
@@ -26,7 +31,7 @@ def solve_trt(sn, n_sample, budgets, potential='job'):
     args_new = gen_argument(args, selected_pairs, neighbors, potential=potential)
     # running exp
     print('computation starts ...')
-    path = './prob/{}/res/{}/efficiency-n{}_id{}.csv'.format(ins_name, potential, n_sample, sn)
+    path = './prob/{}/res{}/{}/efficiency-n{}_id{}.csv'.format(ins_name, suffix, potential, n_sample, sn)
     print('\nVarying budget in ', budgets)
     if os.path.exists(path):
         vals = pd.read_csv(path).values.tolist()
@@ -57,7 +62,8 @@ if __name__ == '__main__':
     parser.add_argument('-b', '--budgets', nargs='+', type=int, help='budgets that we want to consider in a list')
     parser.add_argument('--n', type=int, help='number of od pairs in the sample')
     parser.add_argument('--potential', type=str, help='the potential for accessibility calculation, job/populations')
+    parser.add_argument('--region', type=str, help='sub-region to limit projects to', default=None)
     args = parser.parse_args()
     # run experiment
     for sn in args.sns:
-        solve_trt(sn, args.n, args.budgets, potential=args.potential)
+        solve_trt(sn, args.n, args.budgets, potential=args.potential, region=args.region)

--- a/solve_trt_opt_map.py
+++ b/solve_trt_opt_map.py
@@ -15,18 +15,23 @@ def extract_projects(proj2art, projects):
     return arts
 
 
-def gen_proj_shp(n, sn, budget, potential, region):
+def gen_proj_shp(n, sn, budget, potential, region=None):
+    # set sub-region suffix
+    if region == None:
+        suffix = ''
+    else:
+        suffix = '_{}'.format(region)
     filename = 'efficiency-n{}_id{}_summary'.format(n, sn)
     budget_col = 'budget'
     project_col = 'projects'
-    df = pd.read_csv('./prob/trt/res_{}/{}/summary/{}.csv'.format(region, potential, filename))
+    df = pd.read_csv('./prob/trt/res{}/{}/summary/{}.csv'.format(suffix, potential, filename))
     projects = df[df[budget_col] <= budget][project_col].values[-1]
     print('Projects: ', projects)
     df_art = gpd.read_file('./data/trt_arterial/trt_arterial.shp')
-    proj2artidx, _ = load_file('./data/trt_instance/proj2artid_{}.pkl'.format(region))
+    proj2artidx, _ = load_file('./data/trt_instance/proj2artid{}.pkl'.format(suffix))
     art_index = extract_projects(proj2artidx, str2list(projects))
     df_selected = df_art.loc[art_index, :].copy()
-    df_selected.to_file(driver='ESRI Shapefile', filename='./prob/trt/res_{}/shp/{}-budget{}.shp'.format(region, filename, budget))
+    df_selected.to_file(driver='ESRI Shapefile', filename='./prob/trt/res{}/shp/{}-budget{}.shp'.format(suffix, filename, budget))
 
 
 if __name__ == '__main__':

--- a/solve_trt_opt_map.py
+++ b/solve_trt_opt_map.py
@@ -15,18 +15,18 @@ def extract_projects(proj2art, projects):
     return arts
 
 
-def gen_proj_shp(n, sn, budget, potential):
+def gen_proj_shp(n, sn, budget, potential, region):
     filename = 'efficiency-n{}_id{}_summary'.format(n, sn)
     budget_col = 'budget'
     project_col = 'projects'
-    df = pd.read_csv('./prob/trt/res/{}/summary/{}.csv'.format(potential, filename))
+    df = pd.read_csv('./prob/trt/res_{}/{}/summary/{}.csv'.format(region, potential, filename))
     projects = df[df[budget_col] <= budget][project_col].values[-1]
     print('Projects: ', projects)
     df_art = gpd.read_file('./data/trt_arterial/trt_arterial.shp')
-    proj2artidx, _ = load_file('./data/trt_instance/proj2artid.pkl')
+    proj2artidx, _ = load_file('./data/trt_instance/proj2artid_{}.pkl'.format(region))
     art_index = extract_projects(proj2artidx, str2list(projects))
     df_selected = df_art.loc[art_index, :].copy()
-    df_selected.to_file(driver='ESRI Shapefile', filename='./prob/trt/res/shp/{}-budget{}.shp'.format(filename, budget))
+    df_selected.to_file(driver='ESRI Shapefile', filename='./prob/trt/res_{}/shp/{}-budget{}.shp'.format(region, filename, budget))
 
 
 if __name__ == '__main__':
@@ -36,7 +36,8 @@ if __name__ == '__main__':
     parser.add_argument('--n', type=int, help='number of od pairs in the sample')
     parser.add_argument('-b', '--budget', type=int, help='budget (km x 4)')
     parser.add_argument('--potential', type=str, help='the potential for accessibility calculation, job/populations')
+    parser.add_argument('--region', type=str, help='region name to check for in folder')
     args = parser.parse_args()
     # generate shapefile
     for sn in args.sns:
-        gen_proj_shp(n=args.n, sn=sn, budget=args.budget, potential=args.potential)
+        gen_proj_shp(n=args.n, sn=sn, budget=args.budget, potential=args.potential, region=args.region)

--- a/solve_trt_opt_res.py
+++ b/solve_trt_opt_res.py
@@ -8,21 +8,21 @@ import os
 import argparse
 
 
-def eval_sol(potential='job',  n=500, sn=10):
+def eval_sol(region, potential='job',  n=500, sn=10):
     # load data
     filename = 'efficiency-n{}_id{}'.format(n, sn)
-    if os.path.exists('./prob/trt/res/{}/{}.csv'.format(potential, filename)):
-        res = pd.read_csv('./prob/trt/res/{}/{}.csv'.format(potential, filename))
+    if os.path.exists('./prob/trt/res_{}/{}/{}.csv'.format(region, potential, filename)):
+        res = pd.read_csv('./prob/trt/res_{}/{}/{}.csv'.format(region, potential, filename))
     else:
         return None
-    sum_path = './prob/trt/res/{}/summary/{}_summary.csv'.format(potential, filename)
+    sum_path = './prob/trt/res_{}/{}/summary/{}_summary.csv'.format(region, potential, filename)
     if os.path.exists(sum_path):
         df = pd.read_csv(sum_path)
         calculated = {b for b in df['budget'].values}
         records = df.values.tolist()
     else:
         records, calculated = [], {}
-    args, _ = load_file('./prob/trt/args.pkl')
+    args, _ = load_file('./prob/trt/args_adj_ratio_{}.pkl'.format(region))
     projs, budgets = res['projects'].values, res['budget_proj'].values
     for idx, p in enumerate(projs):
         if budgets[idx] in calculated:
@@ -40,7 +40,8 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--sns', nargs='+', type=int, help='series number of the p-median samples in a list')
     parser.add_argument('--n', type=int, help='number of od pairs in the sample')
     parser.add_argument('--potential', type=str, help='the potential for accessibility calculation, job/populations')
+    parser.add_argument('--region', type=str, help='region name to check for in folder')
     args = parser.parse_args()
     # calculate accessibility
     for sn in args.sns:
-        eval_sol(potential=args.potential, n=args.n, sn=sn)
+        eval_sol(region=args.region, potential=args.potential, n=args.n, sn=sn)

--- a/solve_trt_opt_res.py
+++ b/solve_trt_opt_res.py
@@ -8,21 +8,26 @@ import os
 import argparse
 
 
-def eval_sol(region, potential='job',  n=500, sn=10):
+def eval_sol(region=None, potential='job',  n=500, sn=10):
+    # set sub-region suffix
+    if region == None:
+        suffix = ''
+    else:
+        suffix = '_{}'.format(region)
     # load data
     filename = 'efficiency-n{}_id{}'.format(n, sn)
-    if os.path.exists('./prob/trt/res_{}/{}/{}.csv'.format(region, potential, filename)):
-        res = pd.read_csv('./prob/trt/res_{}/{}/{}.csv'.format(region, potential, filename))
+    if os.path.exists('./prob/trt/res{}/{}/{}.csv'.format(suffix, potential, filename)):
+        res = pd.read_csv('./prob/trt/res{}/{}/{}.csv'.format(suffix, potential, filename))
     else:
         return None
-    sum_path = './prob/trt/res_{}/{}/summary/{}_summary.csv'.format(region, potential, filename)
+    sum_path = './prob/trt/res{}/{}/summary/{}_summary.csv'.format(suffix, potential, filename)
     if os.path.exists(sum_path):
         df = pd.read_csv(sum_path)
         calculated = {b for b in df['budget'].values}
         records = df.values.tolist()
     else:
         records, calculated = [], {}
-    args, _ = load_file('./prob/trt/args_adj_ratio_{}.pkl'.format(region))
+    args, _ = load_file('./prob/trt/args_adj_ratio{}.pkl'.format(suffix))
     projs, budgets = res['projects'].values, res['budget_proj'].values
     for idx, p in enumerate(projs):
         if budgets[idx] in calculated:
@@ -40,7 +45,7 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--sns', nargs='+', type=int, help='series number of the p-median samples in a list')
     parser.add_argument('--n', type=int, help='number of od pairs in the sample')
     parser.add_argument('--potential', type=str, help='the potential for accessibility calculation, job/populations')
-    parser.add_argument('--region', type=str, help='region name to check for in folder')
+    parser.add_argument('--region', type=str, help='sub-region name', default=None)
     args = parser.parse_args()
     # calculate accessibility
     for sn in args.sns:

--- a/solver/continuous/greedy.py
+++ b/solver/continuous/greedy.py
@@ -105,7 +105,7 @@ class GreedySolverPar:
             idx += 1
             records.append((allocated, curr_acc, selected.copy()))
             df = pd.DataFrame(records, columns=['allocated', 'acc', 'selected'])
-            dump_file('./prob/trt/res{}/greedy_{}_{}_{}_par.pkl'.format(self.suffix, self.metric, self.potential, budget), df)
+            df.to_csv('./prob/trt/res{}/greedy_{}_{}_{}_par.pkl'.format(self.suffix, self.metric, self.potential, budget), index=False)
             print('selected: {}, new acc: {}, metric: {}, allocated: {}'.format(best_idx, curr_acc, best_val, allocated))
 
     @staticmethod

--- a/solver/continuous/greedy.py
+++ b/solver/continuous/greedy.py
@@ -105,7 +105,7 @@ class GreedySolverPar:
             idx += 1
             records.append((allocated, curr_acc, selected.copy()))
             df = pd.DataFrame(records, columns=['allocated', 'acc', 'selected'])
-            df.to_csv('./prob/trt/res{}/greedy_{}_{}_{}_par.pkl'.format(self.suffix, self.metric, self.potential, budget), index=False)
+            df.to_csv('./prob/trt/res{}/greedy_{}_{}_{}_par.csv'.format(self.suffix, self.metric, self.potential, budget), index=False)
             print('selected: {}, new acc: {}, metric: {}, allocated: {}'.format(best_idx, curr_acc, best_val, allocated))
 
     @staticmethod

--- a/solver/continuous/greedy.py
+++ b/solver/continuous/greedy.py
@@ -7,9 +7,15 @@ import multiprocessing
 
 class GreedySolver:
 
-    def __init__(self, metric='abs'):
+    def __init__(self, metric='abs', region=None):
         self.metric = metric
         self.n_worker = 8
+        # set sub-region suffix
+        if region == None:
+            suffix = ''
+        else:
+            suffix = '_{}'.format(region)
+        self.suffix = suffix
 
     def search(self, projs, args, selected, curr_acc, remained):
         best_val, best_inc, best_idx, new_curr = 0, 0, -1, curr_acc
@@ -25,7 +31,8 @@ class GreedySolver:
                 best_idx = p
         return best_val, new_curr, best_idx
 
-    def solve(self, args, budget, region):
+    def solve(self, args, budget):
+
         # extract info
         projs = list(range(len(args['projects'])))
         proj_costs = args['project_costs']
@@ -49,16 +56,22 @@ class GreedySolver:
             idx += 1
             records.append((allocated, curr_acc, selected.copy()))
             df = pd.DataFrame(records, columns=['allocated', 'acc', 'selected'])
-            dump_file('./prob/trt/res/greedy_{}_{}_{}.pkl'.format(self.metric, budget, region), df)
+            dump_file('./prob/trt/res{}/greedy_{}_{}.pkl'.format(self.suffix, self.metric, budget), df)
             print('selected: {}, new acc: {}, metric: {}, allocated: {}'.format(best_idx, curr_acc, best_val, allocated))
 
 
 class GreedySolverPar:
 
-    def __init__(self, metric='abs', n_workers=8, potential='populations'):
+    def __init__(self, metric='abs', n_workers=8, potential='populations', region=None):
         self.metric = metric
         self.n_workers = n_workers
         self.potential = potential
+        # set sub-region suffix
+        if region == None:
+            suffix = ''
+        else:
+            suffix = '_{}'.format(region)
+        self.suffix = suffix
 
     def search(self, projs, args, selected, curr_acc, remained):
         proj_costs = args['project_costs']
@@ -92,7 +105,7 @@ class GreedySolverPar:
             idx += 1
             records.append((allocated, curr_acc, selected.copy()))
             df = pd.DataFrame(records, columns=['allocated', 'acc', 'selected'])
-            dump_file('./prob/trt/res/greedy_{}_{}_par.pkl'.format(self.metric, self.potential), df)
+            dump_file('./prob/trt/res{}/greedy_{}_{}_par.pkl'.format(self.suffix, self.metric, self.potential), df)
             print('selected: {}, new acc: {}, metric: {}, allocated: {}'.format(best_idx, curr_acc, best_val, allocated))
 
     @staticmethod

--- a/solver/continuous/greedy.py
+++ b/solver/continuous/greedy.py
@@ -105,7 +105,7 @@ class GreedySolverPar:
             idx += 1
             records.append((allocated, curr_acc, selected.copy()))
             df = pd.DataFrame(records, columns=['allocated', 'acc', 'selected'])
-            dump_file('./prob/trt/res{}/greedy_{}_{}_par.pkl'.format(self.suffix, self.metric, self.potential), df)
+            dump_file('./prob/trt/res{}/greedy_{}_{}_{}_par.pkl'.format(self.suffix, self.metric, self.potential, budget), df)
             print('selected: {}, new acc: {}, metric: {}, allocated: {}'.format(best_idx, curr_acc, best_val, allocated))
 
     @staticmethod

--- a/solver/continuous/greedy.py
+++ b/solver/continuous/greedy.py
@@ -56,7 +56,7 @@ class GreedySolver:
             idx += 1
             records.append((allocated, curr_acc, selected.copy()))
             df = pd.DataFrame(records, columns=['allocated', 'acc', 'selected'])
-            dump_file('./prob/trt/res{}/greedy_{}_{}.pkl'.format(self.suffix, self.metric, budget), df)
+            df.to_csv('./prob/trt/res{}/greedy_{}_{}.csv'.format(self.suffix, self.metric, budget), index=False)
             print('selected: {}, new acc: {}, metric: {}, allocated: {}'.format(best_idx, curr_acc, best_val, allocated))
 
 

--- a/solver/continuous/greedy.py
+++ b/solver/continuous/greedy.py
@@ -25,7 +25,7 @@ class GreedySolver:
                 best_idx = p
         return best_val, new_curr, best_idx
 
-    def solve(self, args, budget):
+    def solve(self, args, budget, region):
         # extract info
         projs = list(range(len(args['projects'])))
         proj_costs = args['project_costs']
@@ -49,7 +49,7 @@ class GreedySolver:
             idx += 1
             records.append((allocated, curr_acc, selected.copy()))
             df = pd.DataFrame(records, columns=['allocated', 'acc', 'selected'])
-            dump_file('./prob/trt/res/greedy_{}.pkl'.format(self.metric), df)
+            dump_file('./prob/trt/res/greedy_{}_{}_{}.pkl'.format(self.metric, budget, region), df)
             print('selected: {}, new acc: {}, metric: {}, allocated: {}'.format(best_idx, curr_acc, best_val, allocated))
 
 

--- a/utils/instance_generator.py
+++ b/utils/instance_generator.py
@@ -1153,13 +1153,13 @@ class RealInstanceGenerator:
     def __init__(self):
         pass
 
-    def generate(self, T=30):
+    def generate(self, region, T=30):
         """
         generate a MaxANDP instance based on Toronto's road network
         :param T: float, travel time limit in minute
         :return: dict of instance components
         """
-        path = './prob/trt/args_adj_new.pkl'
+        path = './prob/trt/args_adj_ratio_%s.pkl' %region
         args, load_succeed = load_file(path)
         if load_succeed:
             if 'job' not in args:

--- a/utils/instance_generator.py
+++ b/utils/instance_generator.py
@@ -1153,13 +1153,18 @@ class RealInstanceGenerator:
     def __init__(self):
         pass
 
-    def generate(self, region, T=30):
+    def generate(self, region=None, T=30):
         """
         generate a MaxANDP instance based on Toronto's road network
         :param T: float, travel time limit in minute
         :return: dict of instance components
         """
-        path = './prob/trt/args_adj_ratio_{}.pkl'.format(region)
+        # set sub-region suffix
+        if region == None:
+            suffix = ''
+        else:
+            suffix = '_{}'.format(region)
+        path = './prob/trt/args_adj_ratio{}.pkl'.format(suffix)
         args, load_succeed = load_file(path)
         if load_succeed:
             if 'job' not in args:

--- a/utils/instance_generator.py
+++ b/utils/instance_generator.py
@@ -1159,7 +1159,7 @@ class RealInstanceGenerator:
         :param T: float, travel time limit in minute
         :return: dict of instance components
         """
-        path = './prob/trt/args_adj_ratio_%s.pkl' %region
+        path = './prob/trt/args_adj_ratio_{}.pkl'.format(region)
         args, load_succeed = load_file(path)
         if load_succeed:
             if 'job' not in args:


### PR DESCRIPTION
Adds a 'region' parameter in all affected functions that defaults to `None` so that original function is preserved without changes.

To use this, create a `args_adj_ratio_region.pkl` and `proj2artid_region.pkl` with the project list subsetted to a particular region.

So far this all works, but maybe we should talk about what the testing architecture is like at some point.